### PR TITLE
Upgrade sync script to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
     "redux": "^4.0.4",
-    "skiller-whale-sync": "^1.4.0",
+    "skiller-whale-sync": "^1.5.0",
     "webpack-cli": "^3.3.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4703,7 +4703,7 @@ signal-exit@^3.0.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-skiller-whale-sync@^1.4.0:
+skiller-whale-sync@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/skiller-whale-sync/-/skiller-whale-sync-1.5.0.tgz#96c591c42be182dee8b5aee19873754f26300d05"
   integrity sha512-FZiHd+5kWNg0oYR+WqY0N6JfAP42948TO0Nlxp7najzpf03RDfvPA0VjPiVjEIBkJJ03hUrJd/Yg1C5XWxVMaA==


### PR DESCRIPTION
The yarn.lock file was already at `1.5.0` based on `^1.4.0`, but this moves the package version to `1.5.0` to prevent downgrades.
